### PR TITLE
fix: zstandard not needed on Python 3.14+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.11, 3.12]
+        python-version: [3.8, 3.11, 3.14]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ download = [
     "httpx<1,>=0.27.0",
 ]
 install = [
-    "zstandard>=0.21.0",
+    "zstandard>=0.21.0; python_version<'3.14'",
 ]
 all = [
     "pbs-installer[download,install]"

--- a/src/pbs_installer/_utils.py
+++ b/src/pbs_installer/_utils.py
@@ -77,6 +77,8 @@ def unpack_zst(filename: str, destination: StrPath) -> None:
     """Unpack the zstd compressed tarfile to the destination"""
     import tempfile
 
+    if sys.version_info >= (3, 14):
+        from compression import zstd
     try:
         import zstandard as zstd
     except ModuleNotFoundError:


### PR DESCRIPTION
Close #15. The zstandard backport doesn't build on all platforms that wheels support. Over time, this should enable using pbs-installer in more places, like on PyPy and GraalPy, when those support 3.14. Also other architectures like riscv as long as Python 3.14+ is being used.
